### PR TITLE
Fix error while setting slider value from text input.

### DIFF
--- a/bootstrap-slider-knockout-binding.js
+++ b/bootstrap-slider-knockout-binding.js
@@ -33,6 +33,6 @@ ko.bindingHandlers.sliderValue = {
 		else
 			valueObservable = modelValue['value'];
 
-		$(element).slider('setValue', valueObservable());
+		$(element).slider('setValue', parseFloat(valueObservable()));
 	}
 };


### PR DESCRIPTION
Hi, I made a small fix. It's preventing from "Uncaught Error Invalid input value 'x' passed in" error, when you have text input connected with slider, for instance:

```
<input type="text" class="slider form-control" data-bind="sliderValue: selectedValue"/>
<input type="text" data-bind="value: selectedValue">
```

And you're trying to manipulate slider value by typing number into this text input.
