### PR TITLE
Update broken jsfiddle

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ The Knockout binding allows you to use an observable as a value for the slider a
 
 You can find an example <a href="http://cosminstefanxp.github.io/bootstrap-slider-knockout-binding/">here</a>.
 
-Also, you can find a working JSFiddle <a href="http://jsfiddle.net/ERz7u/21/">here</a>.
+Also, you can find a working JSFiddle <a href="http://jsfiddle.net/ERz7u/51/">here</a>.

--- a/bootstrap-slider-knockout-binding.js
+++ b/bootstrap-slider-knockout-binding.js
@@ -15,9 +15,11 @@ ko.bindingHandlers.sliderValue = {
 		else {
 			valueObservable = params['value'];
 			if (!Array.isArray(valueObservable)) {
-				// Replace the 'value' field in the options object with the actual value
-				params['value'] = ko.unwrap(valueObservable);
-				$(element).slider(params);
+				// Replace the 'value' field in the options object for slider with the actual value
+				// Keep observable around in params object
+				var unwrappedParams = JSON.parse(JSON.stringify(params));
+				unwrappedParams['value'] = ko.unwrap(valueObservable);
+				$(element).slider(unwrappedParams);
 			}
 			else {
 				valueObservable = [params['value'][0], params['value'][1]];
@@ -38,11 +40,11 @@ ko.bindingHandlers.sliderValue = {
 			}
 		}).on('change', function (ev) {
 			if (!Array.isArray(valueObservable)) {
-				valueObservable(ev.value.newValue)
+				valueObservable(ev.value['newValue'])
 			}
 			else {
-				valueObservable[0](ev.value.newValue[0]);
-				valueObservable[1](ev.value.newValue[1]);
+				valueObservable[0](ev.value['newValue'][0]);
+				valueObservable[1](ev.value['newValue'][1]);
 			}
 		});
 


### PR DESCRIPTION
The JSFiddle linked to in the Readme was broken. At first I thought the whole ko binding was unusable, but it really just needed a reference to a CDN file instead of a Github raw link. Updated fiddle is working as expected.